### PR TITLE
Fix right click

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,13 @@ app.on("ready", () => {
       },
     ];
 
+    tray.on("right-click", () => {
+      mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate));
+    });
+
     tray.on("click", (e) => {
-      //show context menu if ctrl or meta key is pressed while clicking or right click
-      e.ctrlKey || e.metaKey || e.button == 2
+      //check if ctrl or meta key is pressed while clicking
+      e.ctrlKey || e.metaKey
         ? mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate))
         : null;
     });

--- a/index.js
+++ b/index.js
@@ -90,10 +90,12 @@ app.on("ready", () => {
       },
     ];
 
-    tray.on("right-click", () => {
-      mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate));
+    tray.on("click", (e) => {
+      //show context menu if ctrl or meta key is pressed while clicking or right click
+      e.ctrlKey || e.metaKey || e.button == 2
+        ? mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate))
+        : null;
     });
-
     const menu = new Menu();
 
     globalShortcut.register("CommandOrControl+Shift+g", () => {


### PR DESCRIPTION
Solves #26 

CTRL or CMD click now works on Mac to show context menu from tray bar

<img width="227" alt="Screenshot 2022-12-07 at 06 16 49" src="https://user-images.githubusercontent.com/1550477/206103042-d90abb8b-c8b5-45b9-84e7-4172582085e9.png">
