### PR TITLE
Add escape key shortcut to hide window

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const {
   Menu,
   globalShortcut,
   shell,
+  MenuItem,
 } = require("electron");
 const contextMenu = require("electron-context-menu");
 
@@ -95,6 +96,14 @@ app.on("ready", () => {
     });
 
     const menu = new Menu();
+    
+    menu.append(new MenuItem({
+      label: 'Local Shortcuts',
+      submenu: [{
+        role: 'exit',
+        accelerator: 'Esc', click: () => { mb.hideWindow() }
+      }]
+    }))
 
     globalShortcut.register("CommandOrControl+Shift+g", () => {
       if (window.isVisible()) {
@@ -105,12 +114,6 @@ app.on("ready", () => {
           mb.app.show();
         }
         mb.app.focus();
-      }
-    });
-
-    globalShortcut.register("Escape", () => {
-      if (window.isVisible()) {
-        mb.hideWindow();
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -108,6 +108,12 @@ app.on("ready", () => {
       }
     });
 
+    globalShortcut.register("Escape", () => {
+      if (window.isVisible()) {
+        mb.hideWindow();
+      }
+    });
+
     Menu.setApplicationMenu(menu);
 
     // open devtools


### PR DESCRIPTION
Hi Vince,

Just a quick contribution as your tool is gaining popularity. I always find myself reaching for the escape key as quick shortcut to minimize a popup, for example when you trigger Apple's Spotlight Search with Command + Space, you can exit it via Escape conveniently.

I added 3 lines to make your tool work the same. I tested it locally and it works as intended. Thanks!