### PR TITLE
Add cut and enter

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,6 @@ app.on("ready", () => {
           // if shift is also pressed, ignore
           if (input.shift) return;
 
-          console.log("enter pressed");
           // press main > form > button
           contents.executeJavaScript(
             `document.querySelector('main form button').click()`

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ app.on("ready", () => {
   mb.on("ready", () => {
     const { window } = mb;
 
-
     if (process.platform !== "darwin") {
       window.setSkipTaskbar(true);
     } else {
@@ -138,7 +137,20 @@ app.on("ready", () => {
       // register cmd+c/cmd+v events
       contents.on("before-input-event", (event, input) => {
         const { control, meta, key } = input;
+
+        if (input.type !== "keyDown" && key == "Enter") {
+          // if shift is also pressed, ignore
+          if (input.shift) return;
+
+          console.log("enter pressed");
+          // press main > form > button
+          contents.executeJavaScript(
+            `document.querySelector('main form button').click()`
+          );
+        }
+
         if (!control && !meta) return;
+        if (key === "x") contents.cut();
         if (key === "c") contents.copy();
         if (key === "v") contents.paste();
         if (key === "a") contents.selectAll();


### PR DESCRIPTION
- Adds `enter` capability back by monitoring input events and sending a `press` event to the form button
- Ignores said event if `shift` is included to allow multi-line
- Add `ctrl+x` for cutting from the selected text