### PR TITLE
Add Zoom controls to context menu and changed shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,31 @@
   </div>
     <script>
     const webview = document.getElementById('webview');
-    webview.addEventListener('dom-ready', function() {
+    
+    // Store current zoom level
+    let currentZoom = 1.0;
+    
+    // Add IPC listeners for zoom controls
+    require('electron').ipcRenderer.on('zoom-in', () => {
+      currentZoom += 0.1;
+      webview.setZoomFactor(currentZoom);
+    });
 
+    require('electron').ipcRenderer.on('zoom-out', () => {
+      currentZoom -= 0.1;
+      if (currentZoom < 0.3) currentZoom = 0.3; // Prevent too much zoom out
+      webview.setZoomFactor(currentZoom);
+    });
+
+    require('electron').ipcRenderer.on('zoom-reset', () => {
+      currentZoom = 1.0;
+      webview.setZoomFactor(currentZoom);
+    });
+
+    webview.addEventListener('dom-ready', function() {
+      // Set initial zoom if desired
+      // webview.setZoomFactor(0.6);
+      
       // hide message below text input, sidebar, suggestions on new chat
       webview.insertCSS(`
         .text-xs.text-center {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ app.on("ready", () => {
         submenu: [
           {
             label: "Zoom In",
-            accelerator: "CommandOrControl+=",
+            accelerator: "CommandOrControl+Plus",
             click: () => {
               const webContents = mb.window.webContents;
               const currentZoom = webContents.getZoomFactor();

--- a/index.js
+++ b/index.js
@@ -88,21 +88,49 @@ app.on("ready", () => {
           shell.openExternal("https://twitter.com/vincelwt");
         },
       },
+      {
+        type: "separator",
+      },
+      {
+        label: "Zoom",
+        submenu: [
+          {
+            label: "Zoom In",
+            accelerator: "CommandOrControl+=",
+            click: () => {
+              const webContents = mb.window.webContents;
+              const currentZoom = webContents.getZoomFactor();
+              webContents.setZoomFactor(currentZoom + 0.1);
+            }
+          },
+          {
+            label: "Zoom Out",
+            accelerator: "CommandOrControl+-",
+            click: () => {
+              const webContents = mb.window.webContents;
+              const currentZoom = webContents.getZoomFactor();
+              const newZoom = Math.max(0.3, currentZoom - 0.1);
+              webContents.setZoomFactor(newZoom);
+            }
+          },
+          {
+            label: "Reset Zoom",
+            accelerator: "CommandOrControl+0",
+            click: () => {
+              mb.window.webContents.setZoomFactor(1.0);
+            }
+          }
+        ]
+      },
     ];
 
     tray.on("right-click", () => {
       mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate));
     });
 
-    tray.on("click", (e) => {
-      //check if ctrl or meta key is pressed while clicking
-      e.ctrlKey || e.metaKey
-        ? mb.tray.popUpContextMenu(Menu.buildFromTemplate(contextMenuTemplate))
-        : null;
-    });
     const menu = new Menu();
 
-    globalShortcut.register("CommandOrControl+Shift+g", () => {
+    globalShortcut.register("Command+Control+c", () => {
       if (window.isVisible()) {
         mb.hideWindow();
       } else {
@@ -139,13 +167,28 @@ app.on("ready", () => {
       contents.on("before-input-event", (event, input) => {
         const { control, meta, key } = input;
         if (!control && !meta) return;
-        if (key === "c") contents.copy();
-        if (key === "v") contents.paste();
-        if (key === "a") contents.selectAll();
-        if (key === "z") contents.undo();
-        if (key === "y") contents.redo();
-        if (key === "q") app.quit();
-        if (key === "r") contents.reload();
+        
+        switch(key) {
+          case "=":
+          case "+":
+          case "plus":
+          case "Equal":
+            contents.setZoomFactor(contents.getZoomFactor() + 0.1);
+            break;
+          case "-":
+            contents.setZoomFactor(Math.max(0.3, contents.getZoomFactor() - 0.1));
+            break;
+          case "0":
+            contents.setZoomFactor(1.0);
+            break;
+          case "c": contents.copy(); break;
+          case "v": contents.paste(); break;
+          case "a": contents.selectAll(); break;
+          case "z": contents.undo(); break;
+          case "y": contents.redo(); break;
+          case "q": app.quit(); break;
+          case "r": contents.reload(); break;
+        }
       });
     }
   });

--- a/index.js
+++ b/index.js
@@ -52,22 +52,37 @@ app.on("ready", () => {
     }
 
     const contextMenuTemplate = [
-      // add links to github repo and vince's twitter
       {
         label: "New Chat",
         accelerator: "Command+N",
         click: () => {
+          if (!window.isVisible()) return;
           const webContents = mb.window.webContents;
-          webContents.executeJavaScript(
-            `document.querySelector('webview').executeJavaScript('document.querySelector(\\'[data-testid="create-new-chat-button"]\\').click()')`
-          );
+          webContents.executeJavaScript(`
+            document.querySelector('webview').executeJavaScript('document.querySelector(\\'[data-testid="create-new-chat-button"]\\').click()')
+          `);
         },
       },
       {
-        label: "Quit",
-        accelerator: "Command+Q",
+        label: "Open new chat in browser",
+        accelerator: "Command+Shift+N",
         click: () => {
-          app.quit();
+          if (!window.isVisible()) return;
+          shell.openExternal('https://chat.openai.com/chat');
+        },
+      },
+      {
+        label: "Open current chat in browser",
+        accelerator: "Command+O",
+        click: () => {
+          if (!window.isVisible()) return;
+          const webContents = mb.window.webContents;
+          // Get the webview element's current URL
+          webContents.executeJavaScript(`
+            document.querySelector('webview')?.getAttribute('src') || 'https://chat.openai.com/chat'
+          `).then(currentUrl => {
+            shell.openExternal(currentUrl);
+          });
         },
       },
       {
@@ -75,12 +90,6 @@ app.on("ready", () => {
         accelerator: "Command+R",
         click: () => {
           window.reload();
-        },
-      },
-      {
-        label: "Open in browser",
-        click: () => {
-          shell.openExternal("https://chat.openai.com/chat");
         },
       },
       {
@@ -132,6 +141,16 @@ app.on("ready", () => {
           }
         ]
       },
+      {
+        type: "separator",
+      },
+      {
+        label: "Quit",
+        accelerator: "Command+Q",
+        click: () => {
+          app.quit();
+        },
+      },
     ];
 
     tray.on("right-click", () => {
@@ -161,9 +180,32 @@ app.on("ready", () => {
             label: 'New Chat',
             accelerator: 'Command+N',
             click: () => {
-              window.webContents.executeJavaScript(
-                'document.querySelector(\'[data-testid="create-new-chat-button"]\').click()'
-              );
+              if (!window.isVisible()) return;
+              const webContents = mb.window.webContents;
+              webContents.executeJavaScript(`
+                document.querySelector('webview').executeJavaScript('document.querySelector(\\'[data-testid="create-new-chat-button"]\\').click()')
+              `);
+            }
+          },
+          {
+            label: 'Open New Chat in Browser',
+            accelerator: 'Command+Shift+N',
+            click: () => {
+              if (!window.isVisible()) return;
+              shell.openExternal('https://chat.openai.com/chat');
+            }
+          },
+          {
+            label: 'Open Current Chat in Browser',
+            accelerator: 'Command+O',
+            click: () => {
+              if (!window.isVisible()) return;
+              const webContents = mb.window.webContents;
+              webContents.executeJavaScript(`
+                document.querySelector('webview')?.getAttribute('src') || 'https://chat.openai.com/chat'
+              `).then(currentUrl => {
+                shell.openExternal(currentUrl);
+              });
             }
           }
         ]
@@ -197,11 +239,6 @@ app.on("ready", () => {
         if (!control && !meta) return;
         
         switch(key) {
-          case "n": 
-            contents.executeJavaScript(
-              'document.querySelector(\'[data-testid="create-new-chat-button"]\').click()'
-            );
-            break;
           case "=":
           case "+":
           case "plus":

--- a/index.js
+++ b/index.js
@@ -54,6 +54,16 @@ app.on("ready", () => {
     const contextMenuTemplate = [
       // add links to github repo and vince's twitter
       {
+        label: "New Chat",
+        accelerator: "Command+N",
+        click: () => {
+          const webContents = mb.window.webContents;
+          webContents.executeJavaScript(
+            `document.querySelector('webview').executeJavaScript('document.querySelector(\\'[data-testid="create-new-chat-button"]\\').click()')`
+          );
+        },
+      },
+      {
         label: "Quit",
         accelerator: "Command+Q",
         click: () => {
@@ -142,7 +152,25 @@ app.on("ready", () => {
       }
     });
 
-    Menu.setApplicationMenu(menu);
+    // Create application menu with shortcuts
+    const menuTemplate = [
+      {
+        label: 'File',
+        submenu: [
+          {
+            label: 'New Chat',
+            accelerator: 'Command+N',
+            click: () => {
+              window.webContents.executeJavaScript(
+                'document.querySelector(\'[data-testid="create-new-chat-button"]\').click()'
+              );
+            }
+          }
+        ]
+      }
+    ];
+
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
 
     // open devtools
     // window.webContents.openDevTools();
@@ -169,6 +197,11 @@ app.on("ready", () => {
         if (!control && !meta) return;
         
         switch(key) {
+          case "n": 
+            contents.executeJavaScript(
+              'document.querySelector(\'[data-testid="create-new-chat-button"]\').click()'
+            );
+            break;
           case "=":
           case "+":
           case "plus":


### PR DESCRIPTION
Added Zoom controls (Zoom In, Zoom Out, Zoom Reset) and shortcuts (**only active when app window is open**).

## Zoom Controls

Adjust the interface size for better readability:
- Zoom In: `Cmd/Ctrl + =`
- Zoom Out: `Cmd/Ctrl + -`
- Reset Zoom: `Cmd/Ctrl + 0`

Also accesible by right-clicking the menubar icon and selecting "Zoom":

![image](https://github.com/user-attachments/assets/8cce3adf-046b-4572-b3df-5e65e97a3110)

## App launch shortcut changed

Changed shortcut from `⌘ + Shift + G` to `^ + ⌘ + C` to avoid overlapping several apps shortcuts such as Finder "Go", Figma, etc.